### PR TITLE
Session 5: エラーハンドリング

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,12 +77,6 @@ jobs:
       - name: Generate codes with build_runner
         run: flutter pub run build_runner build -d
 
-      - name: Generate translations
-        run: flutter pub run slang
-
-      - name: Generate i18n
-        run: flutter pub run slang
-
       - name: Accept Android License
         if: matrix.os == 'ubuntu-latest'
         run: yes | flutter doctor --android-licenses

--- a/lib/ui/component/error_dialog.dart
+++ b/lib/ui/component/error_dialog.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class ErrorDialogWidget extends StatelessWidget {
+  const ErrorDialogWidget({
+    required this.title,
+    required this.description,
+    required this.actions,
+    super.key,
+  });
+
+  final String title;
+  final String description;
+  final List<Widget> actions;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      title: Text(title),
+      content: Text(description),
+      actions: actions,
+    );
+  }
+}

--- a/lib/ui/mixin/delayed_action.dart
+++ b/lib/ui/mixin/delayed_action.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+mixin DelayedActionMixin on ConsumerWidget {
+  final delayDuration = Duration.zero;
+
+  Future<void> registerDelayedAction(
+    BuildContext context,
+    void Function() action,
+  ) async {
+    await WidgetsBinding.instance.endOfFrame.then(
+      (_) async {
+        await Future<void>.delayed(delayDuration);
+        if (context.mounted) {
+          action();
+        }
+      },
+    );
+  }
+}

--- a/lib/ui/view/home_view/home_view.dart
+++ b/lib/ui/view/home_view/home_view.dart
@@ -1,29 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_training/ui/mixin/delayed_action.dart';
 import 'package:flutter_training/ui/view/route.dart';
 
-class HomeView extends ConsumerWidget {
-  const HomeView({super.key});
+class HomeView extends ConsumerWidget with DelayedActionMixin {
+  HomeView({super.key});
+
+  @override
+  // ignore: overridden_fields
+  final delayDuration = const Duration(milliseconds: 500);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    WidgetsBinding.instance.endOfFrame.then(
-      (_) async {
-        await Future<void>.delayed(
-          const Duration(milliseconds: 500),
-        );
-        // ↓ state.mountedでも良い
-        if (context.mounted) {
-          // 直近のRouteを取得
-          final router = ref.read(routerProvider);
-          // 既にWeatherResultViewに遷移している場合は何もしない
-          if (router.location == const WeatherResultViewRoute().location) {
-            return;
-          }
-          const WeatherResultViewRoute().push(context);
-        }
-      },
-    );
+    registerDelayedAction(context, () {
+      // 直近のRouteを取得
+      final router = ref.read(routerProvider);
+      // 既にWeatherResultViewに遷移している場合は何もしない
+      if (router.location == const WeatherResultViewRoute().location) {
+        return;
+      }
+      const WeatherResultViewRoute().push(context);
+    });
+
     return const SizedBox.expand(
       child: DecoratedBox(
         decoration: BoxDecoration(

--- a/lib/ui/view/route.dart
+++ b/lib/ui/view/route.dart
@@ -15,7 +15,7 @@ class HomeRoute extends GoRouteData {
   const HomeRoute();
 
   @override
-  Widget build(BuildContext context, GoRouterState state) => const HomeView();
+  Widget build(BuildContext context, GoRouterState state) => HomeView();
 }
 
 @TypedGoRoute<WeatherResultViewRoute>(

--- a/lib/ui/view/weather_result_view/weather_result_view.dart
+++ b/lib/ui/view/weather_result_view/weather_result_view.dart
@@ -4,6 +4,8 @@ import 'package:flutter_training/model/enum/weather_category.dart';
 import 'package:flutter_training/ui/component/weather_item_widget.dart';
 import 'package:flutter_training/ui/view/route.dart';
 import 'package:flutter_training/ui/view/weather_result_view/weather_result_viewmodel.dart';
+import 'package:go_router/go_router.dart';
+import 'package:yumemi_weather/yumemi_weather.dart';
 
 class WeatherResultView extends ConsumerWidget {
   const WeatherResultView({super.key});
@@ -39,9 +41,43 @@ class WeatherResultView extends ConsumerWidget {
                             child: const Text('Close'),
                           ),
                           TextButton(
-                            onPressed: () => ref
-                                .read(weatherResultViewModelProvider.notifier)
-                                .fetchWeather(),
+                            onPressed: () {
+                              try {
+                                ref
+                                    .read(
+                                      weatherResultViewModelProvider.notifier,
+                                    )
+                                    .fetchThrowsWeather();
+                              } on YumemiWeatherError {
+                                ref
+                                    .read(
+                                  weatherResultViewModelProvider.notifier,
+                                )
+                                    .showErrorDialog(
+                                  title: 'エラーが発生しました',
+                                  description: '再試行してください',
+                                  context: context,
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => context.pop(),
+                                      child: const Text('CLOSE'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () {
+                                        context.pop();
+                                        ref
+                                            .read(
+                                              weatherResultViewModelProvider
+                                                  .notifier,
+                                            )
+                                            .fetchThrowsWeather();
+                                      },
+                                      child: const Text('RETRY'),
+                                    )
+                                  ],
+                                );
+                              }
+                            },
                             child: const Text('Reload'),
                           ),
                         ],

--- a/lib/ui/view/weather_result_view/weather_result_viewmodel.dart
+++ b/lib/ui/view/weather_result_view/weather_result_viewmodel.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_training/model/enum/weather_category.dart';
 import 'package:flutter_training/model/weather_result_view/weather_result_state.dart';
+import 'package:flutter_training/ui/component/error_dialog.dart';
 import 'package:yumemi_weather/yumemi_weather.dart';
 
 class WeatherResultViewModel extends StateNotifier<WeatherResultState> {
@@ -8,6 +10,7 @@ class WeatherResultViewModel extends StateNotifier<WeatherResultState> {
 
   final _api = YumemiWeather();
 
+  @Deprecated('fetchThrowsWeatherを使ってください')
   void fetchWeather() {
     final result = _api.fetchSimpleWeather();
     final category = WeatherCategory.fromString(result);
@@ -15,6 +18,30 @@ class WeatherResultViewModel extends StateNotifier<WeatherResultState> {
       category: category,
     );
   }
+
+  void fetchThrowsWeather() {
+    final result = _api.fetchThrowsWeather('area');
+    final category = WeatherCategory.fromString(result);
+    state = state.copyWith(
+      category: category,
+    );
+  }
+
+  Future<void> showErrorDialog({
+    required String title,
+    required String description,
+    required List<Widget> actions,
+    required BuildContext context,
+  }) =>
+      showDialog<void>(
+        context: context,
+        builder: (context) => ErrorDialogWidget(
+          title: title,
+          description: description,
+          actions: actions,
+        ),
+        barrierDismissible: false,
+      );
 }
 
 final weatherResultViewModelProvider =


### PR DESCRIPTION
## 課題
- [x] 使用する API を fetchSimpleWeather() から fetchThrowsWeather() に変更する
- [x] API のエラーを補足して、エラーの内容に応じて [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) でメッセージを表示する
メッセージの内容は自由
- [x] [AlertDialog](https://api.flutter.dev/flutter/material/AlertDialog-class.html) の ~~OK ボタン~~ CLOSEボタンをタップすると、ダイアログを閉じる

## 対応箇所
- 上記課題
  - OKボタンですが、分かりにくいのでCLOSEボタンにしました

## 動作
![output](https://user-images.githubusercontent.com/73390859/220683236-3899d49b-cbcd-4ca6-89a5-e10f44c28a2a.gif)

